### PR TITLE
fix: update prices from euros to reais on products page

### DIFF
--- a/src/pages/Products.tsx
+++ b/src/pages/Products.tsx
@@ -140,8 +140,8 @@ const Products = () => {
                 </tr>
                 <tr>
                   <td className="py-4 px-6 text-white">Preço</td>
-                  <td className="py-4 px-6 text-center font-semibold text-white">€997</td>
-                  <td className="py-4 px-6 text-center font-semibold text-white">€397</td>
+                  <td className="py-4 px-6 text-center font-semibold text-white">R$ 5.997,00</td>
+                  <td className="py-4 px-6 text-center font-semibold text-white">R$ 2.397,00</td>
                 </tr>
                 <tr className="bg-telemetria-dark/50">
                   <td className="py-4 px-6 text-white">Disponibilidade</td>


### PR DESCRIPTION
## Summary
- Updates the comparison table on the products page to display prices in Brazilian Reais (R$) instead of Euros
- Changes €997 → R$ 5.997,00 for "Especialização em OTel"
- Changes €397 → R$ 2.397,00 for "Trilha OTel"

## Test plan
- [x] Verify prices display correctly in Reais on /produtos page
- [x] Confirm prices match the values in product-data.ts

🤖 Generated with [Claude Code](https://claude.ai/code)