### PR TITLE
feat: make Trilha OTel unavailable

### DIFF
--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -44,11 +44,6 @@ const ProductCard = ({
           : "border-border hover:border-telemetria-yellow/30 hover:shadow-lg"
       )}
     >
-      {popular && (
-        <div className="absolute -top-4 left-1/2 -translate-x-1/2 rounded-full bg-telemetria-yellow px-3 py-1 text-xs font-semibold text-telemetria-dark">
-          Disponível
-        </div>
-      )}
 
       <div className="flex flex-col space-y-6 h-full">
         <div className="space-y-2">

--- a/src/data/product-data.ts
+++ b/src/data/product-data.ts
@@ -398,9 +398,8 @@ export const productData: Product[] = [
       }
     ],
     price: "R$ 2.397,00",
-    ctaText: "Comprar agora",
-    ctaLink: "https://mn.dosedetelemetria.com/users/onboarding/choose_plan?plan_id=1764302&bundle_token=f055362f994c50af8e95a84c787cc1fb&utm_source=manual",
-    available: true,
-    popular: true
+    ctaText: "Lista de espera",
+    ctaLink: "/waiting-list",
+    available: false
   }
 ];

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -98,9 +98,6 @@ const Index = () => {
             
             <div className="glass-morphism rounded-xl p-8 flex flex-col h-full">
               <h3 className="text-2xl font-bold mb-4">Trilha OTel</h3>
-              <div className="inline-block ml-0 mb-4 px-3 py-1 bg-telemetria-yellow/20 border border-telemetria-yellow/30 text-xs rounded-full text-telemetria-yellow">
-                Disponível agora
-              </div>
               <p className="text-white/80 mb-6">
                 Curso completo disponível no seu ritmo, com aulas gravadas, exercícios práticos e acesso vitalício. 
                 Do básico ao avançado em observabilidade e instrumentação.

--- a/src/pages/Products.tsx
+++ b/src/pages/Products.tsx
@@ -151,8 +151,8 @@ const Products = () => {
                     </span>
                   </td>
                   <td className="py-4 px-6 text-center">
-                    <span className="inline-block px-3 py-1 bg-green-500/20 text-green-400 text-xs rounded-full">
-                      Disponível
+                    <span className="inline-block px-3 py-1 bg-yellow-500/20 text-yellow-400 text-xs rounded-full">
+                      Em breve
                     </span>
                   </td>
                 </tr>


### PR DESCRIPTION
## Summary
- Made the Trilha OTel product unavailable to match the Especialização status
- Updated UI to reflect the unavailable state consistently across the site

## Changes
- Set Trilha product as unavailable with "Lista de espera" CTA button
- Removed all "Disponível" badges from ProductCard component and Index page
- Updated Products comparison table to show "Em breve" status for Trilha
- Removed yellow glow styling (popular flag) from Trilha card to match Especialização styling

🤖 Generated with [Claude Code](https://claude.ai/code)